### PR TITLE
Failing icon on extiverse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "title": "CustomHeader",
       "category": "",
       "icon": {
-        "name": "fa-solid fa-file-code",
+        "name": "fas fa-file-code",
         "backgroundColor": "green",
         "color": "white"
       }


### PR DESCRIPTION
fa-solid is not a valid prefix, either use `far` (most common) or `fas`